### PR TITLE
draw and select test separation

### DIFF
--- a/act.svg/tests/setup
+++ b/act.svg/tests/setup
@@ -16,7 +16,7 @@ se_xpath="//textarea[@id='svgFullTextarea']"
 se_xpath="//textarea[@id='svgFullTextarea']"
 . ns run se-element-xpath
 (
-    # put svg text in post-start
+    # put svg text in pre-start
     ft_start=
     ft_end=v0.1
     . ns run version-between
@@ -40,7 +40,7 @@ se_xpath="//button[@id='buttonStart']"
 . ns run se-element-click
 
 (
-    # put svg text in pre-start
+    # put svg text in post-start
     ft_start=v0.2
     ft_end=
     . ns run version-between

--- a/act.svg/tests/setup
+++ b/act.svg/tests/setup
@@ -40,7 +40,7 @@ se_xpath="//button[@id='buttonStart']"
 . ns run se-element-click
 
 (
-    # put svg text in post-start
+    # put svg text in pre-start
     ft_start=v0.2
     ft_end=
     . ns run version-between

--- a/act.svg/tests/setup
+++ b/act.svg/tests/setup
@@ -1,67 +1,74 @@
 #!/bin/bash
 
-. ns import sel_sid ft_index ft_wait
+. ns import sel_sid ft_index ft_wait stp_svg
 se_wait="$ft_wait"
 # GO TO CURRENT CODE VERSION INDEX PAGE
 se_sid="$sel_sid"
 se_url="http://localhost:8000/${ft_index}"
 . ns run se-session-url
-sleep "$ft_wait"
 
 # LOCATE TEXTAREA AND CLEAR IT
 se_xpath="//textarea[@id='svgFullTextarea']"
 . ns run se-element-xpath
 . ns run se-element-clear
-sleep "$ft_wait"
 
 # SET (EMPTY OR RECT) SVG VALUE
 se_xpath="//textarea[@id='svgFullTextarea']"
 . ns run se-element-xpath
 (
+    # put svg text in post-start
     ft_start=
-    ft_end=devbox
+    ft_end=v0.1
     . ns run version-between
     if [[ $ft_found -eq 1 ]]; then
         read -r -d '' se_text <<EOF
-<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='750' height='750' viewBox='0,0,750,750'><rect x='71' y='101' rx='0' ry='0' width='200' height='200' stroke='black' fill='transparent' stroke-width='1'/></svg>
+<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='750' height='750' viewBox='0,0,750,750'>${stp_svg}</svg>
 EOF
-    else
-        read -r -d '' se_text <<EOF
-<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='750' height='750' viewBox='0,0,750,750'></svg>
-EOF
+        . ns run se-element-value
     fi
-    . ns run se-element-value
 )
-sleep "$ft_wait"
+
 
 # force the on-change
 se_xpath="//svg"
 . ns run se-element-xpath
 . ns run se-element-click
-sleep "$ft_wait"
 
 # LOCATE START BUTTON AND CLICK IT
 se_xpath="//button[@id='buttonStart']"
 . ns run se-element-xpath
 . ns run se-element-click
-sleep "$ft_wait"
+
+(
+    # put svg text in post-start
+    ft_start=v0.2
+    ft_end=
+    . ns run version-between
+    if [[ $ft_found -eq 1 ]]; then
+        se_xpath="//textarea[@id='svgFullTextarea']"
+        . ns run se-element-xpath
+        # echo "$se_found"
+        read -r -d '' se_text <<EOF
+<svg version='1.1' xmlns='http://www.w3.org/2000/svg' xmlns:xlink='http://www.w3.org/1999/xlink' width='750' height='750' viewBox='0,0,750,750'>${stp_svg}</svg>
+EOF
+        . ns run se-element-value # se-* scripts all end with: sleep $se_wait
+    fi
+)
 
 # force the on-change
 se_xpath="//*[name()='svg']"  # /*[name()='rect']"
 . ns run se-element-xpath
 . ns run se-element-click
-sleep "$ft_wait"
 
-# remove svg textarea focus:
-se_x=751
-se_y=151
-se_x2=801
-se_y2=201
+# remove svg textarea focus (no-op clicks on rhs of pane, draw/selections on lhs):
+se_x=1051
+se_y=451
+se_x2=1101
+se_y2=501
 . ns run se-actions-dragged-click
 
 # select mode
 se_keys="0"
 . ns run se-actions-keys
-sleep "$ft_wait"
 
 . ns export sel_sid ft_index ft_wait

--- a/act.svg/tests/test-000-selection-rect
+++ b/act.svg/tests/test-000-selection-rect
@@ -7,39 +7,13 @@ se_wait=$ft_wait
 # TEST ONE - TEST RECTANGLE CAN BE SELECTED
 test="RECTANGLE CAN BE SELECTED"
 
+# must use single quotes (until setup script is updated)
+read -r -d '' stp_svg <<EOF
+<rect rx='0' ry='0' x='24' y='86' width='197' height='197' stroke='black' fill='transparent' stroke-width='1'/>
+EOF
 . ns run setup
 
 se_sid="$sel_sid"
-
-# rect mode
-se_keys="3"
-. ns run se-actions-keys
-sleep "$se_wait"
-
-# draw rect
-se_x=771
-se_y=171
-se_x2=971
-se_y2=371
-(
-    ft_start=
-    ft_end=v0.0
-    . ns run version-between
-    if [[ $ft_found -gt 0 ]]; then
-        # two-click draw
-        ft_start=v0.0
-        ft_end=v0.0
-        . ns run version-between
-        if [[ $ft_found -gt 0 ]]; then
-            # only click-draw rect if version is >= v0.0
-            # as initial (devbox) version only supports selection
-            . ns run se-actions-diagonal-clicks
-        fi
-    else
-        # click-and-drag draw
-        . ns run se-actions-dragged-click
-    fi
-)
 
 # select mode
 se_keys="0"
@@ -51,7 +25,6 @@ sleep "$se_wait"
 se_x=855
 se_y=275
 . ns run se-actions-click
-sleep "$se_wait"
 
 se_xpath="//*[name()='rect']"
 . ns run se-element-xpath

--- a/act.svg/tests/test-001-draw-rect
+++ b/act.svg/tests/test-001-draw-rect
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+. ns import ft_harness ft_index sel_sid ft_wait
+
+se_wait=$ft_wait
+
+# TEST TWO - TEST RECTANGLE CAN BE DRAWN
+test="RECTANGLE CAN BE DRAWN"
+
+stp_svg=
+. ns run setup
+
+se_sid="$sel_sid"
+
+# rect mode
+se_keys="3"
+. ns run se-actions-keys
+sleep "$se_wait"
+
+# draw rect
+se_x=771
+se_y=171
+se_x2=971
+se_y2=371
+(
+    ft_start=
+    ft_end=v0.0
+    . ns run version-between
+    if [[ $ft_found -gt 0 ]]; then
+        # two-click draw
+        ft_start=v0.0
+        ft_end=v0.0
+        . ns run version-between
+        if [[ $ft_found -gt 0 ]]; then
+            # only click-draw rect if version is >= v0.0
+            # as initial (devbox) version only supports selection
+            . ns run se-actions-diagonal-clicks
+        fi
+    else
+        # click-and-drag draw
+        . ns run se-actions-dragged-click
+    fi
+)
+
+se_xpath="//*[name()='rect']"
+. ns run se-element-xpath
+
+# VERSION(S) ASSERT
+ft_assert=$se_found
+ft_start=v0.0
+ft_end=
+. ns run version-assert
+dots=".............................................."
+test="${ft_sut_v} TEST (${ft_status}) ${test}"
+dotl=${#dots}; testl=${#test}; ((dotl-=testl)); dots="${dots:0:$dotl}"; test="${test}.${dots}."
+if [[ $ft_assert -eq 1 ]]; then
+    echo "${test}...PASS"
+else
+    echo "${test}...FAIL"
+fi
+. ns export ft_harness ft_index sel_sid ft_wait

--- a/global.js
+++ b/global.js
@@ -1,5 +1,0 @@
-const { versionAssert } = require('./versionAssert');
-
-module.exports = {
-    versionAssert
-};

--- a/se-actions-keys
+++ b/se-actions-keys
@@ -10,6 +10,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 key_actions=
 let n=${#se_keys}-1;
 for i in $(seq 0 $n)

--- a/se-element-clear
+++ b/se-element-clear
@@ -8,6 +8,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 curl -s -H "$header1" -d '{}' ${base_url}/${se_sid}/element/${se_eid}/clear 1>/dev/null 2>&1
 sleep "$se_wait"
 

--- a/se-element-click
+++ b/se-element-click
@@ -8,6 +8,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 curl -s -H "$header1" -d '{}' ${base_url}/${se_sid}/element/${se_eid}/click 1>/dev/null 2>&1
 sleep "$se_wait"
 

--- a/se-element-value
+++ b/se-element-value
@@ -8,6 +8,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 read -r -d '' body <<EOF
 {
     "text": "${se_text}"

--- a/se-element-xpath
+++ b/se-element-xpath
@@ -8,6 +8,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 read -r -d '' body <<EOF
 {
     "using": "xpath",

--- a/se-session-url
+++ b/se-session-url
@@ -8,6 +8,8 @@ read header1 <<EOF
 Content-Type: application/json; charset=utf-8
 EOF
 
+sleep "$se_wait"
+
 read -r -d '' body <<EOF
 {
     "url": "$se_url"


### PR DESCRIPTION
- selection tests don't need to also test drawing (just fill in the svg contents to be selected)
- selenium se-* scripts should would before and after the script for each user action since the user might have missed a wait time before invocating the script
- user test does not need to sleep after a se-* script call